### PR TITLE
Eliminate duplicate entries from reaching the xml file.

### DIFF
--- a/src/xmltv.ts
+++ b/src/xmltv.ts
@@ -1,6 +1,9 @@
 import type { GridApiResponse } from "./tvlistings.js";
 import { Command } from "commander";
 
+// TF 10/2025 Add node.js module needed for helper function.
+import assert from "assert";
+
 export function escapeXml(unsafe: string): string {
   return unsafe
     .replace(/&/g, "&amp;")
@@ -91,6 +94,18 @@ function toDdProgid(rawId: string | undefined | null): string | null {
   return m ? `${m[1]}.${m[2]}` : null;
 }
 
+// TF 10/2025 Impement an internal deepStrictEqual function to compare to objects.
+// Helper to compare two objects.
+
+function isIdentical(obj1: any, obj2: any): boolean {
+  try {
+    assert.deepStrictEqual(obj1,obj2);
+  } catch(error) {
+    return false
+  }
+return true
+}
+
 export function buildChannelsXml(data: GridApiResponse): string {
   let xml = "";
 
@@ -155,8 +170,19 @@ export function buildProgramsXml(data: GridApiResponse): string {
     const sortedEvents = [...channel.events].sort(
       (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
     );
+// TF 10/2025 Impement duplicate checking and skip duplicate entries.
 
-    for (const event of sortedEvents) {
+    //for (const event of sortedEvents) {
+    for (let i=0; i<sortedEvents.length; i++) {
+      let event = sortedEvents[i]!;
+
+      if (i>0) {
+        let pevent = sortedEvents[(i-1)]!;
+        if (isIdentical(event, pevent)) {
+          continue
+        }
+      }
+
       xml += `  <programme start="${formatDate(
         event.startTime
       )}" stop="${formatDate(event.endTime)}" channel="${escapeXml(channel.channelId)}">\n`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "useDefineForClassFields": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
### Description

Fixes #15 
Duplicate entries were corrupting the guide in NextPVR and causing recording failure. 
Chose to implement a full object compare rather than a limited property compare mostly because the changes were completed prior to the alternative being presented. Nonetheless, using a full object compare will be more resilient to future data changes as the comparison does not rely on a specific set of property names or values.

### Testing
Ran a short 120 hour request for usa ota for zip 34119.
Did this both prior  to code changes and after. Then compared the two xml files in windiff.
Clearly saw the duplicate entries in the former and not present in the latter. Expected show data was properly formatted
and present in the new xmltv file.

### New dependencies
imports the assert module so a minor addition to the build config file was also required.